### PR TITLE
Fix a NPE thrown when the item from ItemSpawnEvent is null.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.fsml</groupId>
     <artifactId>HoloDrops</artifactId>
-    <version>2.6</version>
+    <version>2.7</version>
     <packaging>jar</packaging>
     <name>HoloDrops</name>
     <description>Shows the item's name above it when dropped.</description>

--- a/src/main/java/me/fsml/holodrops/listeners/ItemDropListener.java
+++ b/src/main/java/me/fsml/holodrops/listeners/ItemDropListener.java
@@ -4,6 +4,7 @@ import me.fsml.holodrops.Main;
 import me.fsml.holodrops.util.Glow;
 import me.fsml.holodrops.util.Strings;
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.entity.Item;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -18,6 +19,9 @@ public class ItemDropListener implements Listener {
     @EventHandler
     public void itemDrop(ItemSpawnEvent e) {
         Item drop = e.getEntity();
+        if(drop.getItemStack().getType() == Material.AIR){
+            return;
+        }
         if (Main.m.settings.isWorldEnabled(drop.getWorld().getName())) {
             ItemStack item = drop.getItemStack();
             if (item.hasItemMeta()) {

--- a/src/main/java/me/fsml/holodrops/util/Strings.java
+++ b/src/main/java/me/fsml/holodrops/util/Strings.java
@@ -44,11 +44,10 @@ public class Strings {
         String itemName = "";
         
         ItemMeta meta = drop.getItemStack().getItemMeta();
-        
         if (drop.getItemStack().getType() == Material.WRITTEN_BOOK) {
             itemName = bookTitle((BookMeta)meta);
         }
-        else if (meta.hasDisplayName() || Main.m.settings.getCustomNamesOnly()) {
+        else if (meta != null && (meta.hasDisplayName() || Main.m.settings.getCustomNamesOnly())) {
             itemName = meta.getDisplayName();
         } else {
             itemName = Main.m.settings.getNameFromMat(drop.getItemStack().getType().toString());


### PR DESCRIPTION
This specifically happened when McRPG would remove items from the BlockDropItemEvent. There would be no items spawning and for some reason, Spigot would still try to spawn an item but it would be null in some regards. Likely a Spigot bug but this is a work around. Has been tested against McRPG and on Spigot 1.14.4 and functions normally without spamming console with errors.